### PR TITLE
Add optional callback performed before step to gsDynamicBase.h

### DIFF
--- a/src/gsDynamicSolvers/gsDynamicBase.h
+++ b/src/gsDynamicSolvers/gsDynamicBase.h
@@ -24,7 +24,8 @@ namespace gismo
 {
 
 /**
-    @brief Performs the arc length method to solve a nonlinear system of equations.
+    @brief Base class for solution strategies of nonlinear second-order dynamic 
+    systems.
 
     \tparam T coefficient type
 
@@ -193,7 +194,7 @@ public:
     // Returns the current time step
     virtual T getTimeStep() const {return m_options.getReal("DT"); }
 
-    /// Perform one arc-length step
+    /// Perform one time step
     virtual gsStatus step(T dt)
     {
         if (m_preStepCallback && !m_preStepCallback(m_time,dt,m_options))
@@ -225,7 +226,7 @@ public:
     }
 
     // Output
-    /// True if the Arc Length method converged
+    /// True if the method converged
     virtual bool converged() const {return m_status==gsStatus::Success;}
 
     /// Returns the number of Newton iterations performed
@@ -249,8 +250,8 @@ public:
     virtual void setVelocities(const gsVector<T> & V)    {this->setV(V);}
     virtual void setAccelerations(const gsVector<T> & A) {this->setA(A);}
 
-    /// @brief Set a function that is called before each timestep. WARNING: This
-    ///        callback is only performed for the non-const step().
+    /// @brief Set a function that is executed when non-const step() is called before
+    ///        the actual step is performed. 
     virtual void setPreStepCallback(const StepCallback_t & callback)
     {
         m_preStepCallback = callback;
@@ -372,7 +373,7 @@ protected:
     /// Number of iterations performed
     mutable index_t m_numIterations;
 
-    // /// Maximum number of Arc Length iterations allowed
+    // /// Maximum number of iterations allowed
     // index_t m_maxIterations;
 
     // /// Number of desired iterations

--- a/src/gsDynamicSolvers/gsDynamicBase.h
+++ b/src/gsDynamicSolvers/gsDynamicBase.h
@@ -51,8 +51,8 @@ protected:
 public:
 
     /// @brief Callback that is evaluated before each timestep.
-    typedef std::function<bool(const T, const T, const gsOptionList &)> StepCallback_t;
-
+    typedef std::function<bool(const T /* time */, const T /* dtime */, 
+        const gsOptionList & /* solver options */)> StepCallback_t;
     virtual ~gsDynamicBase() {};
 
     /// Constructor

--- a/src/gsDynamicSolvers/gsDynamicBase.h
+++ b/src/gsDynamicSolvers/gsDynamicBase.h
@@ -49,6 +49,9 @@ protected:
 
 public:
 
+    /// @brief Callback that is evaluated before each timestep.
+    typedef std::function<bool(const T, const T, const gsOptionList &)> StepCallback_t;
+
     virtual ~gsDynamicBase() {};
 
     /// Constructor
@@ -193,8 +196,15 @@ public:
     /// Perform one arc-length step
     virtual gsStatus step(T dt)
     {
+        if (m_preStepCallback && !m_preStepCallback(m_time,dt,m_options))
+        {
+            m_status = gsStatus::OtherError;
+            return m_status;
+        }
+
         gsStatus status = this->_step(m_time,dt,m_U,m_V,m_A);
         m_time += dt;
+        m_status = status;
         return status;
     }
 
@@ -238,6 +248,19 @@ public:
     virtual void setDisplacements(const gsVector<T> & U) {this->setU(U);}
     virtual void setVelocities(const gsVector<T> & V)    {this->setV(V);}
     virtual void setAccelerations(const gsVector<T> & A) {this->setA(A);}
+
+    /// @brief Set a function that is called before each timestep. WARNING: This
+    ///        callback is only performed for the non-const step().
+    virtual void setPreStepCallback(const StepCallback_t & callback)
+    {
+        m_preStepCallback = callback;
+    }
+
+    /// @brief Clear the pre-step callback.
+    virtual void clearPreStepCallback()
+    {
+        m_preStepCallback = StepCallback_t();
+    }
 
     /// Access the options
     virtual gsOptionList & options() {return m_options;};
@@ -334,6 +357,8 @@ protected:
 
     Residual_t  m_residual;
     TResidual_t m_Tresidual;
+
+    StepCallback_t m_preStepCallback;
 
     mutable typename gsSparseSolver<T>::uPtr m_solver; // Cholesky by default
 

--- a/src/gsStructuralAnalysisTools/gsStructuralAnalysisTypes.h
+++ b/src/gsStructuralAnalysisTools/gsStructuralAnalysisTypes.h
@@ -11,6 +11,8 @@
     Author(s): H.M. Verhelst (2019-..., TU Delft)
 */
 
+#pragma once
+
 #include <functional>
 #include <gsCore/gsLinearAlgebra.h>
 


### PR DESCRIPTION
I have some boundary DOFs with prescribed velocities. Every Newmark timestep, I needed to compute consistens accelerations/positions, and resulting internal forces. This change enables that by making it possible to inject a callback.

Also, a #pragma once was missing.